### PR TITLE
Continue if the subsystem is already gone

### DIFF
--- a/cgroup1/cgroup.go
+++ b/cgroup1/cgroup.go
@@ -259,6 +259,10 @@ func (c *cgroup) Delete() error {
 		// kernel prevents cgroups with running process from being removed, check the tree is empty
 		procs, err := c.processes(s.Name(), true, cgroupProcs)
 		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				// this subsystem is already deleted, nothing to do
+				continue
+			}
 			return err
 		}
 		if len(procs) > 0 {


### PR DESCRIPTION
In v1 cgroups, multiple directories point to the same directory. When all of these controllers are enabled at the same time, this library tries to delete the directories it already deleted (because of the symlinks). So, I fixed it.

```
root@root:/sys/fs/cgroup# ls -l
total 0
drwxr-xr-x 3 root root  0 Feb 10 10:49 blkio
lrwxrwxrwx 1 root root 11 Feb 10 10:49 cpu -> cpu,cpuacct
lrwxrwxrwx 1 root root 11 Feb 10 10:49 cpuacct -> cpu,cpuacct
drwxr-xr-x 3 root root  0 Feb 10 10:49 cpu,cpuacct
drwxr-xr-x 3 root root  0 Feb 10 10:49 cpuset
drwxr-xr-x 3 root root  0 Feb 10 10:49 devices
drwxr-xr-x 3 root root  0 Feb 10 10:49 freezer
drwxr-xr-x 3 root root  0 Feb 10 10:49 hugetlb
drwxr-xr-x 3 root root  0 Feb 10 10:49 memory
dr-xr-xr-x 2 root root  0 Feb 10 10:24 misc
lrwxrwxrwx 1 root root 16 Feb 10 10:49 net_cls -> net_cls,net_prio
drwxr-xr-x 3 root root  0 Feb 10 10:49 net_cls,net_prio
lrwxrwxrwx 1 root root 16 Feb 10 10:49 net_prio -> net_cls,net_prio
drwxr-xr-x 3 root root  0 Feb 10 10:49 perf_event
drwxr-xr-x 3 root root  0 Feb 10 10:49 pids
drwxr-xr-x 3 root root  0 Feb 10 10:49 rdma
drwxr-xr-x 2 root root  0 Feb 10 10:49 systemd
```